### PR TITLE
fix: missing module export for 'Resolvable' decorator

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -3,6 +3,7 @@ export * from './container/Container';
 
 // Decorators
 export * from './decorators/Reflectable';
+export * from './decorators/Resolvable';
 
 // Events
 export * from './events/EventEmitter';


### PR DESCRIPTION
Fixes an issue where the `@Resolvable` decorator was not exported while the [documentation](https://github.com/baileyherbert/common#resolvable) indicates that it should be.