### PR TITLE
Improve versatility of the abstract LogWriter class

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -3,6 +3,7 @@ export * from './container/Container';
 
 // Decorators
 export * from './decorators/Reflectable';
+export * from './decorators/Resolvable';
 
 // Events
 export * from './events/EventEmitter';

--- a/src/logging/LogConsoleWriter.ts
+++ b/src/logging/LogConsoleWriter.ts
@@ -86,11 +86,14 @@ export class LogConsoleWriter extends LogWriter {
 	/**
 	 * Writes log output to the destination.
 	 *
-	 * @param level
-	 * @param text
+	 * @param event An object specifying the details of the log message.
 	 */
-	protected _write(level: LogLevel, text: string) {
-		switch (level) {
+	protected _write(event: LogEvent) {
+		// Build the complete log message
+		const text = this._getLogPrefix(event) + event.content;
+
+		// Write the message to the console
+		switch (event.level) {
 			case LogLevel.Error: return console.error(text);
 			case LogLevel.Warn: return console.warn(text);
 			case LogLevel.Debug:
@@ -98,7 +101,7 @@ export class LogConsoleWriter extends LogWriter {
 			case LogLevel.Info: return console.info(text);
 		}
 
-		throw new Error('Unknown log level: ' + level);
+		throw new Error('Unknown log level: ' + event.level);
 	}
 
 }

--- a/src/logging/LogWriter.ts
+++ b/src/logging/LogWriter.ts
@@ -61,34 +61,15 @@ export abstract class LogWriter {
 	 */
 	private _execute(event: LogEvent) {
 		if (event.level >= this.logLevel) {
-			this._write(event.level, this._format(event));
+			this._write(event);
 		}
-	}
-
-	/**
-	 * Formats log output into a single string for writing.
-	 *
-	 * @param event
-	 */
-	protected _format(event: LogEvent): string {
-		return this._getLogPrefix(event) + event.content;
-	}
-
-	/**
-	 * Returns the prefix to use for the log event. If no prefix should be used, must return an empty string.
-	 *
-	 * @param event
-	 */
-	protected _getLogPrefix(event: LogEvent): string {
-		return '';
 	}
 
 	/**
 	 * Writes log output to the destination.
 	 *
-	 * @param level
-	 * @param text
+	 * @param event An object specifying the details of the log message.
 	 */
-	 protected abstract _write(level: LogLevel, text: string): void | Promise<void>;
+	 protected abstract _write(event: LogEvent): void | Promise<void>;
 
 }


### PR DESCRIPTION
Moves the implementation-specific methods of `LogWriter` out of the abstract `LogWriter` class and into the specific implementations of `LogWriter` that require them. This allows descendants of `LogWriter` to use the `LogEvent` object which includes more details than were previously passed to the abstract `_write` method.

While the `_getLogPrefix` member of `LogWriter` could previously access the `LogEvent` object, not all log writers are going to be building a string, so the idea of a prefix does not always apply.